### PR TITLE
add previously missed ecl legacy resources

### DIFF
--- a/scrapers/earthchem.py
+++ b/scrapers/earthchem.py
@@ -162,7 +162,10 @@ earthchem_urls = [
     'https://doi.org/10.1594/IEDA/100240',
     'https://doi.org/10.1594/IEDA/100241',
     'https://doi.org/10.1594/IEDA/100242',
-    'https://doi.org/10.1594/IEDA/100243'
+    'https://doi.org/10.1594/IEDA/100243',
+    'https://doi.org/10.26022/IEDA/112721',
+    'https://doi.org/10.26022/IEDA/112309',
+    'https://doi.org/10.26022/IEDA/112285'
 ]
 
 async def retrieve_jsonld(urls):


### PR DESCRIPTION
@luciaprofeta  asked for 3 pre-CZO ecl resources to be added to the discovery catalog:

Perdrial,J., Ruckhaus,M., Seybold,E. 2023. Soil leachate from core experiments flushed with solutions of different composition to simulate impact on shifts in acid deposition on soil solute release 2020-2021 [DOI](https://doi.org/10.26022/IEDA/112721)
Munroe,J. 2022. Data from the DUST^2 Project, Collectors DUST-1 through DUST-17, winter 2020-21 and summer 2021 [DOI](https://doi.org/10.26022/IEDA/112309)
Munroe,J. 2023. Dust Deposition in the Uinta Mountains, 2011-2021 [DOI](https://doi.org/10.26022/IEDA/112285)