### PR TITLE
[#112] - pass environment variables to dspfront

### DIFF
--- a/docker-compose-upstream.yml
+++ b/docker-compose-upstream.yml
@@ -12,6 +12,12 @@ services:
       - dspback
     ports:
       - 5001:5001
+    environment:
+      - VUE_APP_HEAP_ANALYTICS_APP_ID=${VUE_APP_HEAP_ANALYTICS_APP_ID}
+      - VUE_APP_GOOGLE_MAPS_API_KEY=${VUE_APP_GOOGLE_MAPS_API_KEY}
+      - VUE_APP_DISCOVERY_PORTAL_URL=${VUE_APP_DISCOVERY_PORTAL_URL}
+      - VUE_APP_API_URL=${VUE_APP_API_URL}
+      - VUE_APP_URL=${VUE_APP_URL}
     restart: unless-stopped
 
   dspback:


### PR DESCRIPTION
In order for the environment variables to be present when starting a docker container via docker-compose, the environment variables must be declared within the docker-compose file.  This PR allows deployments of dspfront to use environment variables in the vue application.