### PR TITLE
Artifact registry tag change

### DIFF
--- a/docker-compose-artifact-registry.yml
+++ b/docker-compose-artifact-registry.yml
@@ -1,6 +1,6 @@
 services:
     dspfront:
-        image: dspfront:latest
+        image: dspfront:${DSPFRONT_AR_TAG}
         container_name: dspfront
         volumes:
             - ./dspfront/.env:/dspfront/.env
@@ -17,7 +17,7 @@ services:
         restart: unless-stopped
 
     dspback:
-        image: dspback:latest
+        image: dspback:${DSPBACK_AR_TAG}
         container_name: dspback
         volumes:
             - ./dspback/.env:/dspback/.env

--- a/docker-compose-artifact-registry.yml
+++ b/docker-compose-artifact-registry.yml
@@ -1,6 +1,6 @@
 services:
     dspfront:
-        image: dspfront:${DSPFRONT_AR_TAG}
+        image: dspfront:${DSPFRONT_TAG}
         container_name: dspfront
         volumes:
             - ./dspfront/.env:/dspfront/.env
@@ -17,7 +17,7 @@ services:
         restart: unless-stopped
 
     dspback:
-        image: dspback:${DSPBACK_AR_TAG}
+        image: dspback:${DSPBACK_TAG}
         container_name: dspback
         volumes:
             - ./dspback/.env:/dspback/.env


### PR DESCRIPTION
Adds a tag to the container when deploying so we don't get mixed up
was "latest" which wasn't useful

new-deployment jobs don't work without this change.